### PR TITLE
Fix yodo1mas.gd error in Godot 4

### DIFF
--- a/Android/yodo1mas.gd
+++ b/Android/yodo1mas.gd
@@ -32,10 +32,10 @@ signal rewarded_ad_closed()
 signal rewarded_ad_earned()
 
 # properties
-export var app_id_ios: String
-export var app_id_android: String
-export var IsPrivacyEnabled: bool
-export var IsAppOpenAdsRequired: bool
+@export var app_id_ios: String
+@export var app_id_android: String
+@export var IsPrivacyEnabled: bool
+@export var IsAppOpenAdsRequired: bool
 
 # "private" properties
 var _yodo1mas_singleton = null


### PR DESCRIPTION
Fixed errors in the yodo1mas.gd file where the word export should be @export in Godot 4.